### PR TITLE
[NF-7101] Add a second entry to download_hrefs for clarification

### DIFF
--- a/pdf_manager_batch.md
+++ b/pdf_manager_batch.md
@@ -46,7 +46,7 @@ title: PDF Manager Batch
 <td><strong>pdf_manager_batch:state</strong></td>
 <td><em>string</em></td>
 <td>Current state of this batch.  When <code>&quot;available&quot;</code>, the batch is ready for download.<br/> <strong>one of:</strong><code>&quot;initializing&quot;</code> or <code>&quot;queued&quot;</code> or <code>&quot;in_progress&quot;</code> or <code>&quot;available&quot;</code> or <code>&quot;success_with_errors&quot;</code> or <code>&quot;empty_list&quot;</code> or <code>&quot;failed&quot;</code></td>
-<td><code>&quot;queued&quot;</code></td>
+<td><code>&quot;success_with_errors&quot;</code></td>
 </tr>
 <tr>
 <td><strong>pdf_manager_batch:download_hrefs</strong></td>
@@ -97,7 +97,7 @@ title: PDF Manager Batch
     &quot;href&quot;: &quot;/api/v1/user_identities/1/pdf_manager_batches/2&quot;,
     &quot;id&quot;: 42,
     &quot;updated_at&quot;: &quot;2016-01-05T16:51:00Z&quot;,
-    &quot;state&quot;: &quot;queued&quot;,
+    &quot;state&quot;: &quot;success_with_errors&quot;,
     &quot;download_hrefs&quot;: [
       &quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;,
       &quot;/api/v1/user_identities/1/pdf_manager_zip_files/3/download&quot;
@@ -136,7 +136,7 @@ title: PDF Manager Batch
       &quot;href&quot;: &quot;/api/v1/user_identities/1/pdf_manager_batches/2&quot;,
       &quot;id&quot;: 2,
       &quot;updated_at&quot;: &quot;2016-01-05T16:51:00Z&quot;,
-      &quot;state&quot;: &quot;queued&quot;,
+      &quot;state&quot;: &quot;success_with_errors&quot;,
       &quot;pdf_manager_template&quot;: {
         &quot;href&quot;: &quot;/api/v1/user_identities/1/pdf_manager_templates/2&quot;,
         &quot;id&quot;: 2,
@@ -214,7 +214,7 @@ title: PDF Manager Batch
     &quot;href&quot;: &quot;/api/v1/user_identities/1/pdf_manager_batches/2&quot;,
     &quot;id&quot;: 42,
     &quot;updated_at&quot;: &quot;2016-01-05T16:51:00Z&quot;,
-    &quot;state&quot;: &quot;queued&quot;,
+    &quot;state&quot;: &quot;success_with_errors&quot;,
     &quot;download_hrefs&quot;: [
       &quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;,
       &quot;/api/v1/user_identities/1/pdf_manager_zip_files/3/download&quot;

--- a/pdf_manager_batch.md
+++ b/pdf_manager_batch.md
@@ -52,7 +52,7 @@ title: PDF Manager Batch
 <td><strong>pdf_manager_batch:download_hrefs</strong></td>
 <td><em>array</em></td>
 <td>When <code>state</code> is <code>&quot;available&quot;</code> or <code>&quot;success_with_errors&quot;</code>, this is an array of hrefs that can be requested with an API key for downloading the generated PDF files.  Otherwise, this is <code>[]</code>.</td>
-<td><code>[&quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;]</code></td>
+<td><code>[&quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;,&quot;/api/v1/user_identities/1/pdf_manager_zip_files/3/download&quot;]</code></td>
 </tr>
 <tr>
 <td><strong>pdf_manager_batch:pdf_manager_template:href</strong></td>
@@ -99,7 +99,8 @@ title: PDF Manager Batch
     &quot;updated_at&quot;: &quot;2016-01-05T16:51:00Z&quot;,
     &quot;state&quot;: &quot;queued&quot;,
     &quot;download_hrefs&quot;: [
-      &quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;
+      &quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;,
+      &quot;/api/v1/user_identities/1/pdf_manager_zip_files/3/download&quot;
     ],
     &quot;pdf_manager_template&quot;: {
       &quot;href&quot;: &quot;/api/v1/user_identities/1/pdf_manager_templates/2&quot;,
@@ -215,7 +216,8 @@ title: PDF Manager Batch
     &quot;updated_at&quot;: &quot;2016-01-05T16:51:00Z&quot;,
     &quot;state&quot;: &quot;queued&quot;,
     &quot;download_hrefs&quot;: [
-      &quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;
+      &quot;/api/v1/user_identities/1/pdf_manager_zip_files/2/download&quot;,
+      &quot;/api/v1/user_identities/1/pdf_manager_zip_files/3/download&quot;
     ],
     &quot;pdf_manager_template&quot;: {
       &quot;href&quot;: &quot;/api/v1/user_identities/1/pdf_manager_templates/2&quot;,

--- a/schemata/pdf_manager_batch.json
+++ b/schemata/pdf_manager_batch.json
@@ -150,7 +150,7 @@
           "comment": "FIXME: Include `items`.  See https://github.com/interagent/prmd/issues/275",
           "type": "array",
           "description": "When `state` is `\"available\"` or `\"success_with_errors\"`, this is an array of hrefs that can be requested with an API key for downloading the generated PDF files.  Otherwise, this is `[]`.",
-          "example": ["/api/v1/user_identities/1/pdf_manager_zip_files/2/download"]
+          "example": ["/api/v1/user_identities/1/pdf_manager_zip_files/2/download", "/api/v1/user_identities/1/pdf_manager_zip_files/3/download"]
         },
         "pdf_manager_template": {
           "type": "object",

--- a/schemata/pdf_manager_batch.json
+++ b/schemata/pdf_manager_batch.json
@@ -54,7 +54,7 @@
                 "state": {
                   "type": "string",
                   "enum": ["initializing", "queued", "in_progress", "available", "success_with_errors", "empty_list", "failed"],
-                  "example": "queued"
+                  "example": "success_with_errors"
                 },
                 "pdf_manager_template": {
                   "type": "object",
@@ -144,7 +144,7 @@
           "type": "string",
           "description": "Current state of this batch.  When `\"available\"`, the batch is ready for download.",
           "enum": ["initializing", "queued", "in_progress", "available", "success_with_errors", "empty_list", "failed"],
-          "example": "queued"
+          "example": "success_with_errors"
         },
         "download_hrefs": {
           "comment": "FIXME: Include `items`.  See https://github.com/interagent/prmd/issues/275",


### PR DESCRIPTION
Add a second entry to download_hrefs for clarification

```
{
  "pdf_manager_batch": {
    "href": "/api/v1/user_identities/1/pdf_manager_batches/2",
    "id": 42,
    "updated_at": "2016-01-05T16:51:00Z",
    "state": "success_with_errors",
    "download_hrefs": [
      "/api/v1/user_identities/1/pdf_manager_zip_files/2/download",
      "/api/v1/user_identities/1/pdf_manager_zip_files/3/download"
    ],
    "pdf_manager_template": {
      "href": "/api/v1/user_identities/1/pdf_manager_templates/2",
      "id": 2,
      "name": "Accepted Offers for Review"
    }
  }
}
```