### PR TITLE
[WA-4653] change program and org ID type

### DIFF
--- a/custom_field.md
+++ b/custom_field.md
@@ -48,7 +48,7 @@ title: Custom Field
 <td><strong>href</strong></td>
 <td><em>string</em></td>
 <td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/programs/\d+/custom_fields</code></td>
-<td><code>&quot;/api/v1/user_identities/1/programs/2/custom_fields&quot;</code></td>
+<td><code>&quot;/api/v1/user_identities/1/programs/42023191739237/custom_fields&quot;</code></td>
 </tr>
 </tbody></table>
 
@@ -71,7 +71,7 @@ title: Custom Field
 </code></pre>
 
 <pre lang="json"><code>{
-  &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/custom_fields&quot;,
+  &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/custom_fields&quot;,
   &quot;custom_fields&quot;: [
     {
       &quot;id&quot;: 4,

--- a/custom_field_answer_boolean.md
+++ b/custom_field_answer_boolean.md
@@ -36,7 +36,7 @@ title: Custom Field Answer (Boolean)
 <td><strong>custom_field_answer:href</strong></td>
 <td><em>string</em></td>
 <td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/programs/\d+/applicants_by_cas_id/\d+/custom_field_answers/\d+</code></td>
-<td><code>&quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
+<td><code>&quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
 </tr>
 <tr>
 <td><strong>custom_field_answer:label</strong></td>
@@ -72,7 +72,7 @@ title: Custom Field Answer (Boolean)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Muggle born?&quot;,
     &quot;field_type&quot;: &quot;boolean&quot;,
@@ -132,7 +132,7 @@ title: Custom Field Answer (Boolean)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Muggle born?&quot;,
     &quot;field_type&quot;: &quot;boolean&quot;,
@@ -162,7 +162,7 @@ title: Custom Field Answer (Boolean)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Muggle born?&quot;,
     &quot;field_type&quot;: &quot;boolean&quot;,

--- a/custom_field_answer_date.md
+++ b/custom_field_answer_date.md
@@ -36,7 +36,7 @@ title: Custom Field Answer (Date)
 <td><strong>custom_field_answer:href</strong></td>
 <td><em>string</em></td>
 <td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/programs/\d+/applicants_by_cas_id/\d+/custom_field_answers/\d+</code></td>
-<td><code>&quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
+<td><code>&quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
 </tr>
 <tr>
 <td><strong>custom_field_answer:label</strong></td>
@@ -72,7 +72,7 @@ title: Custom Field Answer (Date)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Acceptance letter mailed on&quot;,
     &quot;field_type&quot;: &quot;date&quot;,
@@ -132,7 +132,7 @@ title: Custom Field Answer (Date)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Acceptance letter mailed on&quot;,
     &quot;field_type&quot;: &quot;date&quot;,
@@ -162,7 +162,7 @@ title: Custom Field Answer (Date)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Acceptance letter mailed on&quot;,
     &quot;field_type&quot;: &quot;date&quot;,

--- a/custom_field_answer_number.md
+++ b/custom_field_answer_number.md
@@ -36,7 +36,7 @@ title: Custom Field Answer (Number)
 <td><strong>custom_field_answer:href</strong></td>
 <td><em>string</em></td>
 <td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/programs/\d+/applicants_by_cas_id/\d+/custom_field_answers/\d+</code></td>
-<td><code>&quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
+<td><code>&quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
 </tr>
 <tr>
 <td><strong>custom_field_answer:label</strong></td>
@@ -72,7 +72,7 @@ title: Custom Field Answer (Number)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Age at admittance&quot;,
     &quot;field_type&quot;: &quot;number&quot;,
@@ -132,7 +132,7 @@ title: Custom Field Answer (Number)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Age at admittance&quot;,
     &quot;field_type&quot;: &quot;number&quot;,
@@ -162,7 +162,7 @@ title: Custom Field Answer (Number)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Age at admittance&quot;,
     &quot;field_type&quot;: &quot;number&quot;,

--- a/custom_field_answer_select.md
+++ b/custom_field_answer_select.md
@@ -36,7 +36,7 @@ title: Custom Field Answer (Select)
 <td><strong>custom_field_answer:href</strong></td>
 <td><em>string</em></td>
 <td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/programs/\d+/applicants_by_cas_id/\d+/custom_field_answers/\d+</code></td>
-<td><code>&quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
+<td><code>&quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
 </tr>
 <tr>
 <td><strong>custom_field_answer:label</strong></td>
@@ -72,7 +72,7 @@ title: Custom Field Answer (Select)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Preferred house&quot;,
     &quot;field_type&quot;: &quot;select&quot;,
@@ -132,7 +132,7 @@ title: Custom Field Answer (Select)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Preferred house&quot;,
     &quot;field_type&quot;: &quot;select&quot;,
@@ -162,7 +162,7 @@ title: Custom Field Answer (Select)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Preferred house&quot;,
     &quot;field_type&quot;: &quot;select&quot;,

--- a/custom_field_answer_string.md
+++ b/custom_field_answer_string.md
@@ -36,7 +36,7 @@ title: Custom Field Answer (String)
 <td><strong>custom_field_answer:href</strong></td>
 <td><em>string</em></td>
 <td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/programs/\d+/applicants_by_cas_id/\d+/custom_field_answers/\d+</code></td>
-<td><code>&quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
+<td><code>&quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;</code></td>
 </tr>
 <tr>
 <td><strong>custom_field_answer:label</strong></td>
@@ -72,7 +72,7 @@ title: Custom Field Answer (String)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Hogwarts ID&quot;,
     &quot;field_type&quot;: &quot;string&quot;,
@@ -132,7 +132,7 @@ title: Custom Field Answer (String)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Hogwarts ID&quot;,
     &quot;field_type&quot;: &quot;string&quot;,
@@ -162,7 +162,7 @@ title: Custom Field Answer (String)
 
 <pre lang="json"><code>{
   &quot;custom_field_answer&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4&quot;,
     &quot;custom_field_id&quot;: 4,
     &quot;label&quot;: &quot;Hogwarts ID&quot;,
     &quot;field_type&quot;: &quot;string&quot;,

--- a/designation.md
+++ b/designation.md
@@ -52,7 +52,7 @@ title: Designation
 <td><strong>designation:href</strong></td>
 <td><em>string</em></td>
 <td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/programs/\d+/applicants_by_cas_id/\d+/designation</code></td>
-<td><code>&quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/designation&quot;</code></td>
+<td><code>&quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/designation&quot;</code></td>
 </tr>
 <tr>
 <td><strong>designation:local_status</strong></td>
@@ -94,7 +94,7 @@ title: Designation
 
 <pre lang="json"><code>{
   &quot;designation&quot;: {
-    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/designation&quot;,
+    &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/designation&quot;,
     &quot;decisions_href&quot;: &quot;/api/v1/user_identities/1/decisions&quot;,
     &quot;decision&quot;: {
       &quot;id&quot;: 42,
@@ -151,7 +151,7 @@ title: Designation
 </code></pre>
 
 <pre lang="json"><code>{
-  &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/2/applicants_by_cas_id/4/designation&quot;,
+  &quot;href&quot;: &quot;/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/4/designation&quot;,
   &quot;decisions_href&quot;: &quot;/api/v1/user_identities/1/decisions&quot;,
   &quot;decision&quot;: {
     &quot;id&quot;: 43,

--- a/organization.md
+++ b/organization.md
@@ -54,9 +54,9 @@ title: Organization
 </tr>
 <tr>
 <td><strong>organizations/id</strong></td>
-<td><em>integer</em></td>
+<td><em>bigint</em></td>
 <td>Unique identifier of this organization.</td>
-<td><code>42</code></td>
+<td><code>42023191739237</code></td>
 </tr>
 <tr>
 <td><strong>organizations/name</strong></td>
@@ -88,7 +88,7 @@ title: Organization
   &quot;href&quot;: &quot;/api/v1/user_identities/1/organizations&quot;,
   &quot;organizations&quot;: [
     {
-      &quot;id&quot;: 42,
+      &quot;id&quot;: 42023191739237,
       &quot;name&quot;: &quot;Demo University School of Public Health&quot;,
       &quot;cycle_name&quot;: &quot;2014 - 2015&quot;,
       &quot;association_name&quot;: &quot;SOPHAS&quot;,

--- a/organization.md
+++ b/organization.md
@@ -54,7 +54,7 @@ title: Organization
 </tr>
 <tr>
 <td><strong>organizations/id</strong></td>
-<td><em>bigint</em></td>
+<td><em>integer</em></td>
 <td>Unique identifier of this organization.</td>
 <td><code>42023191739237</code></td>
 </tr>

--- a/program.md
+++ b/program.md
@@ -28,9 +28,9 @@ title: Program
 </tr>
 <tr>
 <td><strong>programs/id</strong></td>
-<td><em>integer</em></td>
+<td><em>bigint</em></td>
 <td>Unique identifier of this program.</td>
-<td><code>42</code></td>
+<td><code>42023191739237</code></td>
 </tr>
 <tr>
 <td><strong>programs/name</strong></td>
@@ -68,7 +68,7 @@ title: Program
   &quot;href&quot;: &quot;/api/v1/user_identities/1/programs&quot;,
   &quot;programs&quot;: [
     {
-      &quot;id&quot;: 42,
+      &quot;id&quot;: 4202319173923742,
       &quot;name&quot;: &quot;Potions&quot;,
       &quot;organization_name&quot;: &quot;Hogwarts School of Witchcraft and Wizardry&quot;
     }

--- a/program.md
+++ b/program.md
@@ -28,7 +28,7 @@ title: Program
 </tr>
 <tr>
 <td><strong>programs/id</strong></td>
-<td><em>bigint</em></td>
+<td><em>integer</em></td>
 <td>Unique identifier of this program.</td>
 <td><code>42023191739237</code></td>
 </tr>

--- a/program.md
+++ b/program.md
@@ -68,7 +68,7 @@ title: Program
   &quot;href&quot;: &quot;/api/v1/user_identities/1/programs&quot;,
   &quot;programs&quot;: [
     {
-      &quot;id&quot;: 4202319173923742,
+      &quot;id&quot;: 42023191739237,
       &quot;name&quot;: &quot;Potions&quot;,
       &quot;organization_name&quot;: &quot;Hogwarts School of Witchcraft and Wizardry&quot;
     }

--- a/schemata/custom_field.json
+++ b/schemata/custom_field.json
@@ -23,7 +23,7 @@
       "type": "string",
       "description": "Hypertext reference to this resource.",
       "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/custom_fields",
-      "example": "/api/v1/user_identities/1/programs/2/custom_fields"
+      "example": "/api/v1/user_identities/1/programs/42023191739237/custom_fields"
     },
     "custom_fields": {
       "type": "array",

--- a/schemata/custom_field_answer_boolean.json
+++ b/schemata/custom_field_answer_boolean.json
@@ -61,7 +61,7 @@
               "href": {
                 "type": "string",
                 "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-                "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+                "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
               },
               "custom_field_id": {
                 "type": "integer",
@@ -96,7 +96,7 @@
           "type": "string",
           "description": "Hypertext reference to this resource.",
           "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-          "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+          "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
         },
         "custom_field_id": {
           "type": "integer",

--- a/schemata/custom_field_answer_date.json
+++ b/schemata/custom_field_answer_date.json
@@ -61,7 +61,7 @@
               "href": {
                 "type": "string",
                 "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-                "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+                "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
               },
               "custom_field_id": {
                 "type": "integer",
@@ -96,7 +96,7 @@
           "type": "string",
           "description": "Hypertext reference to this resource.",
           "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-          "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+          "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
         },
         "custom_field_id": {
           "type": "integer",

--- a/schemata/custom_field_answer_number.json
+++ b/schemata/custom_field_answer_number.json
@@ -61,7 +61,7 @@
               "href": {
                 "type": "string",
                 "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-                "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+                "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
               },
               "custom_field_id": {
                 "type": "integer",
@@ -96,7 +96,7 @@
           "type": "string",
           "description": "Hypertext reference to this resource.",
           "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-          "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+          "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
         },
         "custom_field_id": {
           "type": "integer",

--- a/schemata/custom_field_answer_select.json
+++ b/schemata/custom_field_answer_select.json
@@ -61,7 +61,7 @@
               "href": {
                 "type": "string",
                 "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-                "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+                "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
               },
               "custom_field_id": {
                 "type": "integer",
@@ -96,7 +96,7 @@
           "type": "string",
           "description": "Hypertext reference to this resource.",
           "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-          "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+          "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
         },
         "custom_field_id": {
           "type": "integer",

--- a/schemata/custom_field_answer_string.json
+++ b/schemata/custom_field_answer_string.json
@@ -61,7 +61,7 @@
               "href": {
                 "type": "string",
                 "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-                "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+                "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
               },
               "custom_field_id": {
                 "type": "integer",
@@ -96,7 +96,7 @@
           "type": "string",
           "description": "Hypertext reference to this resource.",
           "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/custom_field_answers/\\d+",
-          "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/custom_field_answers/4"
+          "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/custom_field_answers/4"
         },
         "custom_field_id": {
           "type": "integer",

--- a/schemata/designation.json
+++ b/schemata/designation.json
@@ -27,7 +27,7 @@
             "type": "string",
             "description": "Hypertext reference to this resource.",
             "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/designation",
-            "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/4/designation"
+            "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/4/designation"
           },
           "decisions_href": {
             "type": "string",

--- a/schemata/designation.json
+++ b/schemata/designation.json
@@ -80,7 +80,7 @@
           "type": "string",
           "description": "Hypertext reference to this resource.",
           "pattern": "/api/v1/user_identities/\\d+/programs/\\d+/applicants_by_cas_id/\\d+/designation",
-          "example": "/api/v1/user_identities/1/programs/2/applicants_by_cas_id/3/designation"
+          "example": "/api/v1/user_identities/1/programs/42023191739237/applicants_by_cas_id/3/designation"
         },
         "decisions_href": {
           "type": "string",

--- a/schemata/organization.json
+++ b/schemata/organization.json
@@ -34,7 +34,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "bigint",
+            "type": "integer",
             "description": "Unique identifier of this organization."
           },
           "name": {

--- a/schemata/organization.json
+++ b/schemata/organization.json
@@ -34,7 +34,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "bigint",
             "description": "Unique identifier of this organization."
           },
           "name": {

--- a/schemata/organization.json
+++ b/schemata/organization.json
@@ -35,7 +35,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "description": "Unique identifier of this organization."
+            "description": "Unique identifier of this organization.",
+            "example": 42023191739237
           },
           "name": {
             "type": "string",

--- a/schemata/program.json
+++ b/schemata/program.json
@@ -34,7 +34,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "description": "Unique identifier of this program."
+            "description": "Unique identifier of this program.",
+            "example": 42023191739237
           },
           "name": {
             "type": "string",

--- a/schemata/program.json
+++ b/schemata/program.json
@@ -33,7 +33,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer",
+            "type": "bigint",
             "description": "Unique identifier of this program."
           },
           "name": {

--- a/schemata/program.json
+++ b/schemata/program.json
@@ -33,7 +33,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "bigint",
+            "type": "integer",
             "description": "Unique identifier of this program."
           },
           "name": {

--- a/script/ci
+++ b/script/ci
@@ -13,6 +13,8 @@ script/generate-docs
 lines_changed_count=$(git diff | wc -l)
 if [ $lines_changed_count -ne 0 ]; then
   echo "[fatal] Lines show as changed.  This likely means the schemata and generated docs are out of sync."
+  echo "[fatal] Output from git diff:"
+  git diff | cat
   exit 1
 fi
 bundle exec jekyll build


### PR DESCRIPTION
* we changed the program and organization ID type to bigint to
accomodate a 64 bit integer coming from CAS, that will be used as a
unique identifier for those models across applicantions and
environments. the identifier will remain unchanged in CAS 3 prod as
well as UAT envs, and in WA envs.
* cas 2 will continue to use the table PK as the id; the PK will be
copied to the new field to keep the API standard for all.