### PR TITLE
[NF-20097] Add the documentation for applicant details

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Liaison-Intl/prmd.git
-  revision: 8cb419a9b12bbf3356fd904a0628679630a85dfd
+  revision: 20b43706b0421b02021f49a5658e2f38fadb3194
   specs:
     prmd (0.13.0)
       erubis (~> 2.7)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,6 +57,7 @@
                 <li><a href="export_by_user_identity.html">Export/Report</a></li>
                 <li><a href="export_files_check_batch.html">Export/Report Files (check status in batch)</a></li>
                 <li><a href="export_files.html">Export/Report Files (initiate a run)</a></li>
+                <li><a href="applicant_details.html">Applicant Details <span class="label label-warning">Prototype</span></a></li>
                 <li role="separator" class="divider"></li>
                 <li class="dropdown-header">Program-Scoped Endpoints</li>
                 <li><a href="custom_field.html">Custom Field</a></li>

--- a/applicant_details.md
+++ b/applicant_details.md
@@ -1,19 +1,29 @@
 ---
 layout: default
-title: Decision
+title: Applicant Details
 ---
 
 <!-- WARNING: This is an automatically generated file.  Do not modify directly.  See script/generate-docs. -->
 
-<h2><a name="resource-decision">Decision</a></h2>
+<h2><a name="resource-applicant_details">Applicant Details</a></h2>
 
 <p>Stability: <code>prototype</code></p>
+<div class="alert alert-warning">
+  <p><strong>This is a prototype resource.</strong></p>
+  <p>A prototype resource is experimental, and major changes are likely. In time, a prototype resource may or may not advance to production.</p>
+</div>
 
 
-<p>An association has a set of valid <strong>decisions</strong> for an applicant.</p>
+<p>Applicant details stores information about the applicant, only some of this information is editable.</p>
 
+<h3><a name="link-PUT-applicant_details-/api/v1/user_identities/:user_identity_id/applicant_details">Applicant Details Update Applicant Details</a></h3>
 
-<h3>Attributes</h3>
+<p>Update a batch of Applicant Details, this endpoint is <strong>limited to 1000 Applicants per call</strong>.</p>
+
+<pre><code>PUT /api/v1/user_identities/:user_identity_id/applicant_details
+</code></pre>
+
+<h4>Required Parameters</h4>
 
 <table><thead>
 <tr>
@@ -24,35 +34,43 @@ title: Decision
 </tr>
 </thead><tbody>
 <tr>
-<td><strong>decisions/id</strong></td>
-<td><em>integer</em></td>
-<td>Unique identifier of this decision.  <strong>NOTE:</strong> This identifier changes between cycles.</td>
-<td><code>42</code></td>
-</tr>
-<tr>
-<td><strong>decisions/name</strong></td>
+<td><strong>applicants:applicant_cas_id</strong></td>
 <td><em>string</em></td>
-<td>Human-readable name for this decision.</td>
-<td><code>&quot;Offer Accepted&quot;</code></td>
-</tr>
-<tr>
-<td><strong>href</strong></td>
-<td><em>string</em></td>
-<td>Hypertext reference to this resource.<br/> <strong>pattern:</strong> <code>/api/v1/user_identities/\d+/decisions</code></td>
-<td><code>&quot;/api/v1/user_identities/1/decisions&quot;</code></td>
+<td>Unique identifier of the applicant.</td>
+<td><code>&quot;123456789&quot;</code></td>
 </tr>
 </tbody></table>
 
-<h3><a name="link-GET-decision-/api/v1/user_identities/:user_identity_id/decisions">Decision List</a></h3>
+<h4>Optional Parameters</h4>
 
-<p>List valid decisions for the association that this user identity belongs to.</p>
-
-<pre><code>GET /api/v1/user_identities/:user_identity_id/decisions
-</code></pre>
+<table><thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead><tbody>
+<tr>
+<td><strong>applicants:redirect_eligible</strong></td>
+<td><em>boolean</em></td>
+<td>True if the applicant is eligible for redirect.</td>
+<td><code>true</code></td>
+</tr>
+</tbody></table>
 
 <h4>Curl Example</h4>
 
-<pre lang="bash"><code>$ curl -n https://api.webadmit.org/api/v1/user_identities/:user_identity_id/decisions \
+<pre lang="bash"><code>$ curl -n -X PUT https://api.webadmit.org/api/v1/user_identities/:user_identity_id/applicant_details \
+  -d &#39;{
+  &quot;applicants&quot;: [
+    {
+      &quot;applicant_cas_id&quot;: &quot;123456789&quot;,
+      &quot;redirect_eligible&quot;: true
+    }
+  ]
+}&#39; \
+  -H &quot;Content-Type: application/json&quot; \
   -H &quot;x-api-key: 0123456789abcdef0123456789abcdef&quot;
 </code></pre>
 
@@ -62,13 +80,6 @@ title: Decision
 </code></pre>
 
 <pre lang="json"><code>{
-  &quot;href&quot;: &quot;/api/v1/user_identities/1/decisions&quot;,
-  &quot;decisions&quot;: [
-    {
-      &quot;id&quot;: 42,
-      &quot;name&quot;: &quot;Offer Accepted&quot;
-    }
-  ]
 }
 </code></pre>
 

--- a/applicant_details.md
+++ b/applicant_details.md
@@ -90,24 +90,32 @@ title: Applicant Details
 <p>When the user_identity is not found</p>
 
 <pre lang="json"><code>{
-  &quot;errors&quot;: {
-    &quot;schema&quot;: [
-      &quot;User identity &#39;999&#39; not found.&quot;
-    ]
-  }
+  &quot;message&quot;: &quot;User identity &#39;999&#39; not found.&quot;
 }
 </code></pre>
 
 <p>When the program is not found</p>
 
 <pre lang="json"><code>{
-  &quot;errors&quot;: {
-    &quot;schema&quot;: [
-      &quot;Program &#39;99999999999&#39; not found.&quot;
-    ]
-  }
+  &quot;message&quot;: &quot;Program &#39;99999999999&#39; not found.&quot;
 }
 </code></pre>
+
+<p>When the applicant is not found</p>
+
+<pre lang="json"><code>{
+  &quot;message&quot;: &quot;Applicant &#39;99999999999&#39; not found.&quot;
+}
+</code></pre>
+
+<p>When the custom field is not found</p>
+
+<pre lang="json"><code>{
+  &quot;message&quot;: &quot;CustomeField &#39;99999999999&#39; not found.&quot;
+}
+</code></pre>
+
+<p>While these error messages are most often associated with resources that don&#39;t exist when making a <code>GET</code> request, please note that the same messages are also the response during <code>POST</code>, <code>PUT</code>, and <code>PATCH</code> requests if any resources specified by parameters cannot be found.</p>
 
 <h4>Generic error message (legacy error)</h4>
 
@@ -119,7 +127,7 @@ title: Applicant Details
 }
 </code></pre>
 
-<p>While <code>404 Not Found</code> is most often associated with resources that don&#39;t exist when making a <code>GET</code> request, please note that <code>404 Not Found</code> is also the response during <code>POST</code>, <code>PUT</code>, and <code>PATCH</code> requests if any resources specified by parameters cannot be found.</p>
+<p>Liaison is currently phasing out this error message in favor of more descriptive messages.  If you encounter this message, please contact your Liaison representative with a detail description of the API request you made and one of our engineers will update the API.</p>
 
 <h3>Unauthorized</h3>
 

--- a/schemata/applicant_details.json
+++ b/schemata/applicant_details.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "id": "/schemata/applicant_details",
+  "title": "Applicant Details",
+  "stability": "prototype",
+  "description": "Applicant details stores information about the applicant, only some of this information is editable.",
+  "links": [
+    {
+      "description": "Update a batch of Applicant Details, this endpoint is **limited to 1000 Applicants per call**.",
+      "href": "/api/v1/user_identities/:user_identity_id/applicant_details",
+      "method": "PUT",
+      "rel": "update",
+      "title": "Update Applicant Details",
+      "http_header": {
+        "x-api-key": "0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "applicants": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["applicant_cas_id"],
+              "properties": {
+                "applicant_cas_id": {
+                  "type": "string",
+                  "description": "Unique identifier of the applicant.",
+                  "example": "123456789"
+                },
+                "redirect_eligible": {
+                  "type": "boolean",
+                  "description": "True if the applicant is eligible for redirect.",
+                  "example": true
+                }
+              }
+            },
+            "minItems": 1,
+            "maxItems": 1000
+          }
+        },
+        "required": ["applicants"]
+      }
+    }
+  ],
+  "type": "object",
+  "strictProperties": true,
+  "properties": {}
+}

--- a/script/generate-docs
+++ b/script/generate-docs
@@ -24,7 +24,13 @@ generate_markdown_from_json_schema() {
     extended_description_filename='/dev/null'
   fi
 
-  footer_filenames=$4
+  if [ -f "$4" ]; then
+    prototype_filename="$4"
+  else
+    prototype_filename='/dev/null'
+  fi
+
+  footer_filenames=$5
 
   if [ -d "$webadmit_path" ]; then
     cp "$webadmit_path/schemata/meta.json" schemata
@@ -64,7 +70,12 @@ extended_description = File.read('$extended_description_filename')
 # The "extra backlash" bug is [fixed][] in v0.11.x but there is another bug that duplicates attributes that started around v0.10.x that is preventing us from upgrading.  @benjaminoakes has spoken with @geemus about this directly.
 #
 #   [fixed]: https://github.com/interagent/prmd/commit/687d20b61a0d08ae16bbe76e59678ee5f4026464
-puts GitHub::Markup.render("tmp/schema.md").sub('<h3>Attributes</h3>', "#{extended_description}\n<h3>Attributes</h3>").gsub(/ \\\s*\n<\/code><\/pre>/m, "\n</code></pre>")
+render = GitHub::Markup.render("tmp/schema.md").sub('<h3>Attributes</h3>', "#{extended_description}\n<h3>Attributes</h3>")
+
+prototype_description = File.read('$prototype_filename')
+render = render.sub('<p>Stability: <code>prototype</code></p>', "<p>Stability: <code>prototype</code></p>\n#{prototype_description}")
+
+puts render.gsub(/ \\\s*\n<\/code><\/pre>/m, "\n</code></pre>")
 RUBY
 
   echo # Without a trailing newline, Jekyll won't serve the file!
@@ -76,21 +87,23 @@ read_config
 if [ ! -d "$webadmit_path" ]; then
   echo "[warn] '$webadmit_path' is not a directory.  Using cached schemata."
 fi
-generate_markdown_from_json_schema 'Decision' 'decision.json' '' 'not_found.md' > 'decision.md'
-generate_markdown_from_json_schema 'Designation' 'designation.json' '' 'designation_errors.md not_found.md' > 'designation.md'
-generate_markdown_from_json_schema 'User Identity' 'user_identity.json' 'user_identity_extended_description.md' '' > 'user_identity.md'
-generate_markdown_from_json_schema 'Organization' 'organization.json' '' 'not_found.md' > 'organization.md'
-generate_markdown_from_json_schema 'Program' 'program.json' '' 'not_found.md' > 'program.md'
-generate_markdown_from_json_schema 'Custom Field' 'custom_field.json' '' 'not_found.md' > 'custom_field.md'
-generate_markdown_from_json_schema 'Custom Field Answer (Boolean)' 'custom_field_answer_boolean.json' '' 'not_found.md' > 'custom_field_answer_boolean.md'
-generate_markdown_from_json_schema 'Custom Field Answer (Number)' 'custom_field_answer_number.json' '' 'not_found.md' > 'custom_field_answer_number.md'
-generate_markdown_from_json_schema 'Custom Field Answer (Date)' 'custom_field_answer_date.json' '' 'not_found.md' > 'custom_field_answer_date.md'
-generate_markdown_from_json_schema 'Custom Field Answer (String)' 'custom_field_answer_string.json' '' 'not_found.md' > 'custom_field_answer_string.md'
-generate_markdown_from_json_schema 'Custom Field Answer (Select)' 'custom_field_answer_select.json' '' 'custom_field_answer_select_errors.md not_found.md' > 'custom_field_answer_select.md'
-generate_markdown_from_json_schema 'PDF Manager Template' 'pdf_manager_template.json' '' 'not_found.md' > 'pdf_manager_template.md'
-generate_markdown_from_json_schema 'PDF Manager Batch' 'pdf_manager_batch.json' '' 'pdf_manager_batch_errors.md not_found.md' > 'pdf_manager_batch.md'
-generate_markdown_from_json_schema 'Export/Report' 'export.json' '' 'not_found.md' > 'export.md'
-generate_markdown_from_json_schema 'Export/Report' 'export_by_user_identity.json' '' 'not_found.md' > 'export_by_user_identity.md'
-generate_markdown_from_json_schema 'Export/Report Files check status in batch' 'export_files_check_batch.json' '' 'not_found.md' > 'export_files_check_batch.md'
-generate_markdown_from_json_schema 'Export/Report Files check status' 'export_files_check.json' '' 'not_found.md' > 'export_files_check.md'
-generate_markdown_from_json_schema 'Export/Report Files initiate a run' 'export_files.json' '' 'not_found.md' > 'export_files.md'
+generate_markdown_from_json_schema 'Decision' 'decision.json' '' '' 'not_found.md' > 'decision.md'
+generate_markdown_from_json_schema 'Designation' 'designation.json' '' '' 'designation_errors.md not_found.md' > 'designation.md'
+generate_markdown_from_json_schema 'User Identity' 'user_identity.json' 'user_identity_extended_description.md' '' '' > 'user_identity.md'
+generate_markdown_from_json_schema 'Organization' 'organization.json' '' '' 'not_found.md' > 'organization.md'
+generate_markdown_from_json_schema 'Program' 'program.json' '' '' 'not_found.md' > 'program.md'
+generate_markdown_from_json_schema 'Custom Field' 'custom_field.json' '' '' 'not_found.md' > 'custom_field.md'
+generate_markdown_from_json_schema 'Custom Field Answer (Boolean)' 'custom_field_answer_boolean.json' '' '' 'not_found.md' > 'custom_field_answer_boolean.md'
+generate_markdown_from_json_schema 'Custom Field Answer (Number)' 'custom_field_answer_number.json' '' '' 'not_found.md' > 'custom_field_answer_number.md'
+generate_markdown_from_json_schema 'Custom Field Answer (Date)' 'custom_field_answer_date.json' '' '' 'not_found.md' > 'custom_field_answer_date.md'
+generate_markdown_from_json_schema 'Custom Field Answer (String)' 'custom_field_answer_string.json' '' '' 'not_found.md' > 'custom_field_answer_string.md'
+generate_markdown_from_json_schema 'Custom Field Answer (Select)' 'custom_field_answer_select.json' '' '' 'custom_field_answer_select_errors.md not_found.md' > 'custom_field_answer_select.md'
+generate_markdown_from_json_schema 'PDF Manager Template' 'pdf_manager_template.json' '' '' 'not_found.md' > 'pdf_manager_template.md'
+generate_markdown_from_json_schema 'PDF Manager Batch' 'pdf_manager_batch.json' '' '' 'pdf_manager_batch_errors.md not_found.md' > 'pdf_manager_batch.md'
+generate_markdown_from_json_schema 'Export/Report' 'export.json' '' '' 'not_found.md' > 'export.md'
+generate_markdown_from_json_schema 'Export/Report' 'export_by_user_identity.json' '' '' 'not_found.md' > 'export_by_user_identity.md'
+generate_markdown_from_json_schema 'Export/Report Files check status in batch' 'export_files_check_batch.json' '' '' 'not_found.md' > 'export_files_check_batch.md'
+generate_markdown_from_json_schema 'Export/Report Files check status' 'export_files_check.json' '' '' 'not_found.md' > 'export_files_check.md'
+generate_markdown_from_json_schema 'Export/Report Files initiate a run' 'export_files.json' '' '' 'not_found.md' > 'export_files.md'
+generate_markdown_from_json_schema 'Applicant Details' 'applicant_details.json' '' 'prototype.md' 'not_found.md' > 'applicant_details.md'
+


### PR DESCRIPTION
We're adding the documentation for the Applicant Details API endpoint, this endpoint allows you to edit the redirect_eligible column from the details table. Note that this endpoint is limited 1000 records per call.

Linked PR: https://github.com/Liaison-Intl/WebAdMIT/pull/7517