### PR TITLE
[WA-5129] Update documentation to match API behaviour.

### DIFF
--- a/not_found.md
+++ b/not_found.md
@@ -6,11 +6,7 @@ When the user_identity is not found
 
 ```json
 {
-  "errors": {
-    "schema": [
-      "User identity '999' not found."
-    ]
-  }
+  "message": "User identity '999' not found."
 }
 ```
 
@@ -18,35 +14,25 @@ When the program is not found
 
 ```json
 {
-  "errors": {
-    "schema": [
-      "Program '99999999999' not found."
-    ]
-  }
+  "message": "Program '99999999999' not found."
 }
 ```
 
-<p>When the applicant is not found</p>
+When the applicant is not found
 
-<pre lang="json"><code>{
-  &quot;errors&quot;: {
-    &quot;schema&quot;: [
-      &quot;Applicant &#39;88888888888&#39; not found.&quot;
-    ]
-  }
+```json
+{
+  "message": "Applicant '99999999999' not found."
 }
-</code></pre>
+```
 
-<p>When the custom field is not found</p>
+When the custom field is not found
 
-<pre lang="json"><code>{
-  &quot;errors&quot;: {
-    &quot;schema&quot;: [
-      &quot;CustomeField &#39;42&#39; not found.&quot;
-    ]
-  }
+```json
+{
+  "message": "CustomeField '99999999999' not found."
 }
-</code></pre>
+```
 
 While these error messages are most often associated with resources that don't exist when making a `GET` request, please note that the same messages are also the response during `POST`, `PUT`, and `PATCH` requests if any resources specified by parameters cannot be found.
 


### PR DESCRIPTION
The 404 response of the API isn't structured like:

```
{
  "errors": {
    "schema": [
      "ERROR MESSAGE HERE."
    ]
  }
}
```

Instead, it's structured like this:

```
{
  "message": "ERROR MESSAGE HERE."
}
```

To commit updates the documentation.