### PR TITLE
[WA-5455][WA-5129] Capitalized export files status

### DIFF
--- a/export_files.md
+++ b/export_files.md
@@ -46,7 +46,7 @@ title: Export/Report Files initiate a run
 <td><strong>export_files/status</strong></td>
 <td><em>string</em></td>
 <td>Current status of this export file.<br/> <strong>one of:</strong><code>&quot;Initializing&quot;</code> or <code>&quot;Queued&quot;</code> or <code>&quot;In Progress&quot;</code> or <code>&quot;Available&quot;</code> or <code>&quot;Success With Errors&quot;</code> or <code>&quot;Empty List&quot;</code> or <code>&quot;Failed&quot;</code></td>
-<td><code>&quot;available&quot;</code></td>
+<td><code>&quot;Available&quot;</code></td>
 </tr>
 <tr>
 <td><strong>href</strong></td>
@@ -101,7 +101,7 @@ title: Export/Report Files initiate a run
     &quot;id&quot;: 74780,
     &quot;href&quot;: &quot;/api/v1/exports/86466/export_files/74780&quot;,
     &quot;export_id&quot;: 86446,
-    &quot;status&quot;: &quot;available&quot;
+    &quot;status&quot;: &quot;Available&quot;
   }
 }
 </code></pre>

--- a/export_files_check.md
+++ b/export_files_check.md
@@ -49,8 +49,8 @@ title: Export/Report Files check status
 <tr>
 <td><strong>export_files:status</strong></td>
 <td><em>string</em></td>
-<td>Current status of this export file.<br/> <strong>one of:</strong><code>&quot;initializing&quot;</code> or <code>&quot;queued&quot;</code> or <code>&quot;in_progress&quot;</code> or <code>&quot;available&quot;</code> or <code>&quot;success_with_errors&quot;</code> or <code>&quot;empty_list&quot;</code> or <code>&quot;failed&quot;</code></td>
-<td><code>&quot;available&quot;</code></td>
+<td>Current status of this export file.<br/> <strong>one of:</strong><code>&quot;Initializing&quot;</code> or <code>&quot;Queued&quot;</code> or <code>&quot;In Progress&quot;</code> or <code>&quot;Available&quot;</code> or <code>&quot;Success With Errors&quot;</code> or <code>&quot;Empty List&quot;</code> or <code>&quot;Failed&quot;</code></td>
+<td><code>&quot;Available&quot;</code></td>
 </tr>
 </tbody></table>
 
@@ -77,7 +77,7 @@ title: Export/Report Files check status
     &quot;id&quot;: 74780,
     &quot;href&quot;: &quot;/api/v1/exports/86466/export_files/74780&quot;,
     &quot;export_id&quot;: 86446,
-    &quot;status&quot;: &quot;available&quot;,
+    &quot;status&quot;: &quot;Available&quot;,
     &quot;download_url&quot;: &quot;https://webadmit-production.s3.amazonaws.com/export_files/reports/000/074/780/d19d6c0a34b7062c4496530f3d5dbfb_original.txt?AWSAccessKeyId=AKIAIT7746URBGHSHEA&amp;Expires=1425359248&amp;Signature=y2jwr78kbVt44xz%2BfaEnp5dXKU%3D&amp;response-content-disposition=attachment%3B%20filename%3DTest-API-Export.csv&amp;response-content-type=text%2Fcsv%3Bcharset%3Diso-8859-1&quot;
   }
 }

--- a/export_files_check_batch.md
+++ b/export_files_check_batch.md
@@ -43,8 +43,8 @@ title: Export/Report Files check status in batch
 <tr>
 <td><strong>export_files/status</strong></td>
 <td><em>string</em></td>
-<td>Current status of this export file.<br/> <strong>one of:</strong><code>&quot;initializing&quot;</code> or <code>&quot;queued&quot;</code> or <code>&quot;in_progress&quot;</code> or <code>&quot;available&quot;</code> or <code>&quot;success_with_errors&quot;</code> or <code>&quot;empty_list&quot;</code> or <code>&quot;failed&quot;</code></td>
-<td><code>&quot;available&quot;</code></td>
+<td>Current status of this export file.<br/> <strong>one of:</strong><code>&quot;Initializing&quot;</code> or <code>&quot;Queued&quot;</code> or <code>&quot;In Progress&quot;</code> or <code>&quot;Available&quot;</code> or <code>&quot;Success With Errors&quot;</code> or <code>&quot;Empty List&quot;</code> or <code>&quot;Failed&quot;</code></td>
+<td><code>&quot;Available&quot;</code></td>
 </tr>
 <tr>
 <td><strong>href</strong></td>
@@ -79,7 +79,7 @@ title: Export/Report Files check status in batch
       &quot;id&quot;: 74780,
       &quot;href&quot;: &quot;/api/v1/exports/86466/export_files/74780&quot;,
       &quot;export_id&quot;: 86446,
-      &quot;status&quot;: &quot;available&quot;
+      &quot;status&quot;: &quot;Available&quot;
     }
   ]
 }

--- a/schemata/export_files.json
+++ b/schemata/export_files.json
@@ -40,7 +40,7 @@
                 "type": "string",
                 "description": "Current status of this export file.",
                 "enum": ["Initializing", "Queued", "In Progress", "Available", "Success With Errors", "Empty List", "Failed"],
-                "example": "available"
+                "example": "Available"
               }
             }
           }
@@ -96,7 +96,7 @@
             "type": "string",
             "description": "Current status of this export file.",
             "enum": ["Initializing", "Queued", "In Progress", "Available", "Success With Errors", "Empty List", "Failed"],
-            "example": "available"
+            "example": "Available"
           }
         }
       }

--- a/schemata/export_files_check.json
+++ b/schemata/export_files_check.json
@@ -39,8 +39,8 @@
               "status": {
                 "type": "string",
                 "description": "Current status of this export file.",
-                "enum": ["initializing", "queued", "in_progress", "available", "success_with_errors", "empty_list", "failed"],
-                "example": "available"
+                "enum": ["Initializing", "Queued", "In Progress", "Available", "Success With Errors", "Empty List", "Failed"],
+                "example": "Available"
               },
               "download_url": {
                 "type": "string",
@@ -81,8 +81,8 @@
         "status": {
           "type": "string",
           "description": "Current status of this export file.",
-          "enum": ["initializing", "queued", "in_progress", "available", "success_with_errors", "empty_list", "failed"],
-          "example": "available"
+          "enum": ["Initializing", "Queued", "In Progress", "Available", "Success With Errors", "Empty List", "Failed"],
+          "example": "Available"
         },
         "download_url": {
           "type": "string",

--- a/schemata/export_files_check_batch.json
+++ b/schemata/export_files_check_batch.json
@@ -47,8 +47,8 @@
                 "status": {
                   "type": "string",
                   "description": "Current status of this export file.",
-                  "enum": ["initializing", "queued", "in_progress", "available", "success_with_errors", "empty_list", "failed"],
-                  "example": "available"
+                  "enum": ["Initializing", "Queued", "In Progress", "Available", "Success With Errors", "Empty List", "Failed"],
+                  "example": "Available"
                 }
               }
             }
@@ -93,8 +93,8 @@
           "status": {
             "type": "string",
             "description": "Current status of this export file.",
-            "enum": ["initializing", "queued", "in_progress", "available", "success_with_errors", "empty_list", "failed"],
-            "example": "available"
+            "enum": ["Initializing", "Queued", "In Progress", "Available", "Success With Errors", "Empty List", "Failed"],
+            "example": "Available"
           }
         }
       }


### PR DESCRIPTION
The API returns capitalized statuses. While this is clearly not a good thing the v1 api is already used by a number of clients so we can't afford to change it now but rather in a future version. Instead we're just changing the documentation to reflect the truth.

**Has WA PR:** https://github.com/Liaison-Intl/WebAdMIT/pull/8351