### PR TITLE
[NF-39351] Update the documentation for batch custom field answers

### DIFF
--- a/batch_custom_field_answers.md
+++ b/batch_custom_field_answers.md
@@ -40,37 +40,43 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 <td><code>74780</code></td>
 </tr>
 <tr>
-<td><strong>batch:result</strong></td>
-<td><em>nullable object</em></td>
-<td>Result of the batch</td>
-<td><code>null</code></td>
-</tr>
-<tr>
-<td><strong>batch:result:custom_field_answers</strong></td>
+<td><strong>batch:results</strong></td>
 <td><em>nullable array</em></td>
 <td>List of the updated custom field answers</td>
-<td><code>[{&quot;applicant_cas_id&quot;:&quot;123456789&quot;,&quot;custom_field_id&quot;:99,&quot;field_type&quot;:&quot;boolean&quot;,&quot;value&quot;:false},{&quot;applicant_cas_id&quot;:&quot;987654321&quot;,&quot;custom_field_id&quot;:123,&quot;field_type&quot;:&quot;string&quot;,&quot;value&quot;:&quot;banana&quot;}]</code></td>
+<td><code>[{&quot;custom_field_answer&quot;:{&quot;custom_field_id&quot;:99,&quot;label&quot;:&quot;Are you a citizen?&quot;,&quot;field_type&quot;:&quot;boolean&quot;,&quot;value&quot;:false},&quot;applicant_cas_id&quot;:&quot;123456789&quot;},{&quot;custom_field_answer&quot;:{&quot;custom_field_id&quot;:123,&quot;label&quot;:&quot;What is your favorite fruit?&quot;,&quot;field_type&quot;:&quot;string&quot;,&quot;value&quot;:&quot;banana&quot;},&quot;applicant_cas_id&quot;:&quot;987654321&quot;}]</code></td>
 </tr>
 <tr>
-<td><strong>batch:result:custom_field_answers/applicant_cas_id</strong></td>
+<td><strong>batch:results/applicant_cas_id</strong></td>
 <td><em>string</em></td>
 <td>The CAS unique identifier of the applicant.</td>
 <td><code>&quot;123456789&quot;</code></td>
 </tr>
 <tr>
-<td><strong>batch:result:custom_field_answers/custom_field_id</strong></td>
+<td><strong>batch:results/custom_field_answer</strong></td>
+<td><em>nullable object</em></td>
+<td>Result of the batch</td>
+<td><code>null</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/custom_field_answer:custom_field_id</strong></td>
 <td><em>integer</em></td>
 <td>Unique identifier of the <strong>custom field</strong> that this answers.</td>
 <td><code>99</code></td>
 </tr>
 <tr>
-<td><strong>batch:result:custom_field_answers/field_type</strong></td>
+<td><strong>batch:results/custom_field_answer:field_type</strong></td>
 <td><em>string</em></td>
 <td>Type of data that the <strong>custom field</strong> stores.</td>
 <td><code>&quot;boolean&quot;</code></td>
 </tr>
 <tr>
-<td><strong>batch:result:custom_field_answers/value</strong></td>
+<td><strong>batch:results/custom_field_answer:label</strong></td>
+<td><em>string</em></td>
+<td>Human-readable label for the custom field..</td>
+<td><code>&quot;What is your favorite color?&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/custom_field_answer:value</strong></td>
 <td><em>string</em></td>
 <td>The value to be stored as an answer to the <strong>custom field</strong>.</td>
 <td><code>false</code></td>
@@ -129,22 +135,26 @@ batch object in the response.</p>
     &quot;id&quot;: 74780,
     &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;,
     &quot;status&quot;: &quot;Available&quot;,
-    &quot;result&quot;: {
-      &quot;custom_field_answers&quot;: [
-        {
-          &quot;applicant_cas_id&quot;: &quot;123456789&quot;,
+    &quot;results&quot;: [
+      {
+        &quot;custom_field_answer&quot;: {
           &quot;custom_field_id&quot;: 99,
+          &quot;label&quot;: &quot;Are you a citizen?&quot;,
           &quot;field_type&quot;: &quot;boolean&quot;,
           &quot;value&quot;: false
         },
-        {
-          &quot;applicant_cas_id&quot;: &quot;987654321&quot;,
+        &quot;applicant_cas_id&quot;: &quot;123456789&quot;
+      },
+      {
+        &quot;custom_field_answer&quot;: {
           &quot;custom_field_id&quot;: 123,
+          &quot;label&quot;: &quot;What is your favorite fruit?&quot;,
           &quot;field_type&quot;: &quot;string&quot;,
           &quot;value&quot;: &quot;banana&quot;
-        }
-      ]
-    }
+        },
+        &quot;applicant_cas_id&quot;: &quot;987654321&quot;
+      }
+    ]
   }
 }
 </code></pre>

--- a/batch_custom_field_answers.md
+++ b/batch_custom_field_answers.md
@@ -28,12 +28,6 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 </tr>
 </thead><tbody>
 <tr>
-<td><strong>batch:href</strong></td>
-<td><em>string</em></td>
-<td>Hypertext reference to the batch.<br/> <strong>pattern:</strong> <code>/api/v2/user_identities/\d+/programs/\d+/batch_custom_field_answers/\d+</code></td>
-<td><code>&quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;</code></td>
-</tr>
-<tr>
 <td><strong>batch:id</strong></td>
 <td><em>integer</em></td>
 <td>Unique identifier of this batch.</td>
@@ -43,7 +37,7 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 <td><strong>batch:results</strong></td>
 <td><em>nullable array</em></td>
 <td>List of the updated custom field answers</td>
-<td><code>[{&quot;custom_field_answer&quot;:{&quot;custom_field_id&quot;:99,&quot;label&quot;:&quot;Are you a citizen?&quot;,&quot;field_type&quot;:&quot;boolean&quot;,&quot;value&quot;:false},&quot;applicant_cas_id&quot;:&quot;123456789&quot;},{&quot;custom_field_answer&quot;:{&quot;custom_field_id&quot;:123,&quot;label&quot;:&quot;What is your favorite fruit?&quot;,&quot;field_type&quot;:&quot;string&quot;,&quot;value&quot;:&quot;banana&quot;},&quot;applicant_cas_id&quot;:&quot;987654321&quot;}]</code></td>
+<td><code>[{&quot;custom_field_answer&quot;:{&quot;custom_field_id&quot;:99,&quot;label&quot;:&quot;Are you a citizen?&quot;,&quot;field_type&quot;:&quot;boolean&quot;,&quot;value&quot;:false},&quot;applicant_cas_id&quot;:&quot;123456789&quot;,&quot;errors&quot;:null},{&quot;custom_field_answer&quot;:{&quot;custom_field_id&quot;:123,&quot;label&quot;:&quot;What is your favorite fruit?&quot;,&quot;field_type&quot;:&quot;string&quot;,&quot;value&quot;:&quot;banana&quot;},&quot;applicant_cas_id&quot;:&quot;987654321&quot;,&quot;errors&quot;:{&quot;applicant&quot;:&quot;No applicant found for that applicant_cas_id&quot;}}]</code></td>
 </tr>
 <tr>
 <td><strong>batch:results/applicant_cas_id</strong></td>
@@ -111,6 +105,12 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 <td>Current status of this batch.<br/> <strong>one of:</strong><code>&quot;Queued&quot;</code> or <code>&quot;In Progress&quot;</code> or <code>&quot;Available&quot;</code> or <code>&quot;Success With Errors&quot;</code> or <code>&quot;Failed&quot;</code></td>
 <td><code>&quot;Available&quot;</code></td>
 </tr>
+<tr>
+<td><strong>href</strong></td>
+<td><em>string</em></td>
+<td>Hypertext reference to the batch.<br/> <strong>pattern:</strong> <code>/api/v2/user_identities/\d+/programs/\d+/batch_custom_field_answers/\d+</code></td>
+<td><code>&quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;</code></td>
+</tr>
 </tbody></table>
 
 <h3><a name="link-GET-batch_custom_field_answers-/api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers/:id">Batch Custom Field Answers Show</a></h3>
@@ -155,9 +155,9 @@ batch object in the response.</p>
 </code></pre>
 
 <pre lang="json"><code>{
+  &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;,
   &quot;batch&quot;: {
     &quot;id&quot;: 74780,
-    &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;,
     &quot;status&quot;: &quot;Available&quot;,
     &quot;results&quot;: [
       {
@@ -167,7 +167,8 @@ batch object in the response.</p>
           &quot;field_type&quot;: &quot;boolean&quot;,
           &quot;value&quot;: false
         },
-        &quot;applicant_cas_id&quot;: &quot;123456789&quot;
+        &quot;applicant_cas_id&quot;: &quot;123456789&quot;,
+        &quot;errors&quot;: null
       },
       {
         &quot;custom_field_answer&quot;: {
@@ -176,7 +177,10 @@ batch object in the response.</p>
           &quot;field_type&quot;: &quot;string&quot;,
           &quot;value&quot;: &quot;banana&quot;
         },
-        &quot;applicant_cas_id&quot;: &quot;987654321&quot;
+        &quot;applicant_cas_id&quot;: &quot;987654321&quot;,
+        &quot;errors&quot;: {
+          &quot;applicant&quot;: &quot;No applicant found for that applicant_cas_id&quot;
+        }
       }
     ]
   }
@@ -249,9 +253,9 @@ batch object in the response.</p>
 </code></pre>
 
 <pre lang="json"><code>{
+  &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;,
   &quot;batch&quot;: {
     &quot;id&quot;: 74780,
-    &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;,
     &quot;status&quot;: &quot;Queued&quot;
   }
 }

--- a/batch_custom_field_answers.md
+++ b/batch_custom_field_answers.md
@@ -52,12 +52,6 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 <td><code>&quot;123456789&quot;</code></td>
 </tr>
 <tr>
-<td><strong>batch:results/custom_field_answer</strong></td>
-<td><em>nullable object</em></td>
-<td>Result of the batch</td>
-<td><code>null</code></td>
-</tr>
-<tr>
 <td><strong>batch:results/custom_field_answer:custom_field_id</strong></td>
 <td><em>integer</em></td>
 <td>Unique identifier of the <strong>custom field</strong> that this answers.</td>
@@ -80,6 +74,36 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 <td><em>string</em></td>
 <td>The value to be stored as an answer to the <strong>custom field</strong>.</td>
 <td><code>false</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors</strong></td>
+<td><em>nullable object</em></td>
+<td></td>
+<td><code>null</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:applicant</strong></td>
+<td><em>string</em></td>
+<td>An error message indicating that the applicant_cas_id provided was invalid.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:creation_error</strong></td>
+<td><em>string</em></td>
+<td>A message explaining why a change could not be completed.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:custom_field</strong></td>
+<td><em>string</em></td>
+<td>An error message indicating that the custom_field_id provided was invalid.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:update_error</strong></td>
+<td><em>string</em></td>
+<td>An error message explaining why the update could not be applied.</td>
+<td><code>&quot;example&quot;</code></td>
 </tr>
 <tr>
 <td><strong>batch:status</strong></td>

--- a/batch_custom_field_answers.md
+++ b/batch_custom_field_answers.md
@@ -1,0 +1,284 @@
+---
+layout: default
+title: Batch Custom Field Answers
+---
+
+<!-- WARNING: This is an automatically generated file.  Do not modify directly.  See script/generate-docs. -->
+
+<h2><a name="resource-batch_custom_field_answers">Batch Custom Field Answers</a></h2>
+
+<p>Update custom field answers for a set of applicants in a single API request using a batch action.
+A batch action is an asynchronous operation that can be created using a first endpoint and then have its result checked
+using another endpoint.
+First the batch action is created using the <strong>POST</strong> (create) endpoint by sending in the request body, the JSON describing all the
+changes to apply. The creation endpoint validates the changes and then schedules the batch to be executed returning a batch
+<strong>id</strong> to check the result later on.
+Then the <strong>GET</strong> (show) endpoint can be used to check the completion of the scheduled batch, using the <strong>id</strong> returned by the
+previous <strong>POST</strong>. Once the batch has finished, the result will be included in the batch object.</p>
+
+
+<h3>Attributes</h3>
+
+<table><thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead><tbody>
+<tr>
+<td><strong>batch:href</strong></td>
+<td><em>string</em></td>
+<td>Hypertext reference to the batch.<br/> <strong>pattern:</strong> <code>/api/v2/user_identities/\d+/programs/\d+/batch_custom_field_answers/\d+</code></td>
+<td><code>&quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:id</strong></td>
+<td><em>integer</em></td>
+<td>Unique identifier of this batch.</td>
+<td><code>74780</code></td>
+</tr>
+<tr>
+<td><strong>batch:result</strong></td>
+<td><em>nullable object</em></td>
+<td>Result of the batch</td>
+<td><code>null</code></td>
+</tr>
+<tr>
+<td><strong>batch:result:custom_field_answers</strong></td>
+<td><em>nullable array</em></td>
+<td>List of the updated custom field answers</td>
+<td><code>[{&quot;applicant_cas_id&quot;:&quot;123456789&quot;,&quot;custom_field_id&quot;:99,&quot;field_type&quot;:&quot;boolean&quot;,&quot;value&quot;:false},{&quot;applicant_cas_id&quot;:&quot;987654321&quot;,&quot;custom_field_id&quot;:123,&quot;field_type&quot;:&quot;string&quot;,&quot;value&quot;:&quot;banana&quot;}]</code></td>
+</tr>
+<tr>
+<td><strong>batch:result:custom_field_answers/applicant_cas_id</strong></td>
+<td><em>string</em></td>
+<td>The CAS unique identifier of the applicant.</td>
+<td><code>&quot;123456789&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:result:custom_field_answers/custom_field_id</strong></td>
+<td><em>integer</em></td>
+<td>Unique identifier of the <strong>custom field</strong> that this answers.</td>
+<td><code>99</code></td>
+</tr>
+<tr>
+<td><strong>batch:result:custom_field_answers/field_type</strong></td>
+<td><em>string</em></td>
+<td>Type of data that the <strong>custom field</strong> stores.</td>
+<td><code>&quot;boolean&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:result:custom_field_answers/value</strong></td>
+<td><em>string</em></td>
+<td>The value to be stored as an answer to the <strong>custom field</strong>.</td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><strong>batch:status</strong></td>
+<td><em>string</em></td>
+<td>Current status of this batch.<br/> <strong>one of:</strong><code>&quot;Queued&quot;</code> or <code>&quot;In Progress&quot;</code> or <code>&quot;Available&quot;</code> or <code>&quot;Success With Errors&quot;</code> or <code>&quot;Failed&quot;</code></td>
+<td><code>&quot;Available&quot;</code></td>
+</tr>
+</tbody></table>
+
+<h3><a name="link-GET-batch_custom_field_answers-/api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers/:id">Batch Custom Field Answers Show</a></h3>
+
+<p>Retrieve the status of a running/done batch action initiated with a previous POST. The <strong>id</strong> parameter is required. It is the id of the batch
+that you wish to check the status of. You may continue to issue this call over a reasonable polling interval (10s) until the batch has finished.
+Once the status of the batch becomes &quot;Available&quot;, the detailed information of the modification applied will be in the &quot;result&quot; property of the
+batch object in the response.</p>
+
+<pre><code>GET /api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers/:id
+</code></pre>
+
+<h4>Required Parameters</h4>
+
+<table><thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead><tbody>
+<tr>
+<td><strong>id</strong></td>
+<td><em>integer</em></td>
+<td>Unique identifier of this batch.</td>
+<td><code>74780</code></td>
+</tr>
+</tbody></table>
+
+<h4>Curl Example</h4>
+
+<pre lang="bash"><code>$ curl -n https://api.webadmit.org/api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers/:id \
+ -G \
+  -d id=74780 \
+  -H &quot;x-api-key: 0123456789abcdef0123456789abcdef&quot;
+</code></pre>
+
+<h4>Response Example</h4>
+
+<pre><code>HTTP/1.1 200 OK
+</code></pre>
+
+<pre lang="json"><code>{
+  &quot;batch&quot;: {
+    &quot;id&quot;: 74780,
+    &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;,
+    &quot;status&quot;: &quot;Available&quot;,
+    &quot;result&quot;: {
+      &quot;custom_field_answers&quot;: [
+        {
+          &quot;applicant_cas_id&quot;: &quot;123456789&quot;,
+          &quot;custom_field_id&quot;: 99,
+          &quot;field_type&quot;: &quot;boolean&quot;,
+          &quot;value&quot;: false
+        },
+        {
+          &quot;applicant_cas_id&quot;: &quot;987654321&quot;,
+          &quot;custom_field_id&quot;: 123,
+          &quot;field_type&quot;: &quot;string&quot;,
+          &quot;value&quot;: &quot;banana&quot;
+        }
+      ]
+    }
+  }
+}
+</code></pre>
+
+<h3><a name="link-POST-batch_custom_field_answers-/api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers">Batch Custom Field Answers Create</a></h3>
+
+<p>Schedule the update of multiple custom field answers with the given applicant CAS IDs and program ID, by creating a batch.</p>
+
+<pre><code>POST /api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers
+</code></pre>
+
+<h4>Required Parameters</h4>
+
+<table><thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+<th>Example</th>
+</tr>
+</thead><tbody>
+<tr>
+<td><strong>custom_field_answers:applicant_cas_id</strong></td>
+<td><em>string</em></td>
+<td>The CAS unique identifier of the applicant.</td>
+<td><code>&quot;123456789&quot;</code></td>
+</tr>
+<tr>
+<td><strong>custom_field_answers:custom_field_id</strong></td>
+<td><em>integer</em></td>
+<td>Unique identifier of the <strong>custom field</strong> that this answers.</td>
+<td><code>4</code></td>
+</tr>
+<tr>
+<td><strong>custom_field_answers:field_type</strong></td>
+<td><em>string</em></td>
+<td>Type of data that the <strong>custom field</strong> stores.<br/> <strong>one of:</strong><code>&quot;boolean&quot;</code> or <code>&quot;number&quot;</code> or <code>&quot;date&quot;</code> or <code>&quot;string&quot;</code> or <code>&quot;select&quot;</code></td>
+<td><code>&quot;boolean&quot;</code></td>
+</tr>
+<tr>
+<td><strong>custom_field_answers:value</strong></td>
+<td><em>nullable [boolean, string, number, date, select]</em></td>
+<td>The value to be stored as an answer to the <strong>custom field</strong>.</td>
+<td><code>false</code></td>
+</tr>
+</tbody></table>
+
+<h4>Curl Example</h4>
+
+<pre lang="bash"><code>$ curl -n -X POST https://api.webadmit.org/api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers \
+  -d &#39;{
+  &quot;custom_field_answers&quot;: [
+    {
+      &quot;applicant_cas_id&quot;: &quot;123456789&quot;,
+      &quot;custom_field_id&quot;: 4,
+      &quot;field_type&quot;: &quot;boolean&quot;,
+      &quot;value&quot;: false
+    }
+  ]
+}&#39; \
+  -H &quot;Content-Type: application/json&quot; \
+  -H &quot;x-api-key: 0123456789abcdef0123456789abcdef&quot;
+</code></pre>
+
+<h4>Response Example</h4>
+
+<pre><code>HTTP/1.1 201 Created
+</code></pre>
+
+<pre lang="json"><code>{
+  &quot;batch&quot;: {
+    &quot;id&quot;: 74780,
+    &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780&quot;,
+    &quot;status&quot;: &quot;Queued&quot;
+  }
+}
+</code></pre>
+
+<h3>Errors</h3>
+
+<h4>Response Example</h4>
+
+<pre><code>HTTP/1.1 422 Unprocessable Entity
+</code></pre>
+
+<pre lang="json"><code>{
+  &quot;errors&quot;: {
+    &quot;schema&quot;: [
+      &quot;The property &#39;#/&#39; did not contain a required property of &#39;custom_field_answers&#39;&quot;
+    ]
+  }
+}
+</code></pre>
+
+<p>The request body did not match the expected request schema. Please check your parameters and try again.</p>
+
+<pre lang="json"><code>{
+  &quot;errors&quot;: {
+    &quot;schema&quot;: [
+      &quot;The property &#39;#/custom_question_answers/0/applicant_cas_id&#39; of type Fixnum did not match the following type: string&quot;
+    ]
+  }
+}
+</code></pre>
+
+<p>The request body did not match the expected value type. In that example, the <code>applicant_cas_id</code> property of the first object (that is, at the <code>0</code> index) must be a String, not an Integer.</p>
+
+<h3>Not Found</h3>
+
+<h4>Specific error messages</h4>
+
+<pre><code>HTTP/1.1 404 Not Found
+</code></pre>
+
+<p>When the user_identity is not found</p>
+
+<pre lang="json"><code>{
+  &quot;message&quot;: &quot;User identity &#39;999&#39; not found.&quot;
+}
+</code></pre>
+
+<p>When the program is not found</p>
+
+<pre lang="json"><code>{
+  &quot;message&quot;: &quot;Program &#39;99999999999&#39; not found.&quot;
+}
+</code></pre>
+
+<h3>Unauthorized</h3>
+
+<h4>Response Example</h4>
+
+<pre><code>HTTP/1.1 401 Unauthorized
+</code></pre>
+
+<p>(Empty response body.)</p>
+

--- a/batch_custom_field_answers_errors.md
+++ b/batch_custom_field_answers_errors.md
@@ -1,0 +1,31 @@
+### Errors
+
+#### Response Example
+
+```
+HTTP/1.1 422 Unprocessable Entity
+```
+
+```json
+{
+  "errors": {
+    "schema": [
+      "The property '#/' did not contain a required property of 'custom_field_answers'"
+    ]
+  }
+}
+```
+
+The request body did not match the expected request schema. Please check your parameters and try again.
+
+```json
+{
+  "errors": {
+    "schema": [
+      "The property '#/custom_question_answers/0/applicant_cas_id' of type Fixnum did not match the following type: string"
+    ]
+  }
+}
+```
+
+The request body did not match the expected value type. In that example, the `applicant_cas_id` property of the first object (that is, at the `0` index) must be a String, not an Integer.

--- a/batch_designations.md
+++ b/batch_designations.md
@@ -237,9 +237,9 @@ feature which will allow you to set the decision even if the local_status is pre
 </code></pre>
 
 <pre lang="json"><code>{
+  &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_designations/74780&quot;,
   &quot;batch&quot;: {
     &quot;id&quot;: 74780,
-    &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_designations/74780&quot;,
     &quot;status&quot;: &quot;Queued&quot;
   }
 }

--- a/batch_designations.md
+++ b/batch_designations.md
@@ -28,46 +28,70 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 </tr>
 </thead><tbody>
 <tr>
-<td><strong>batch:href</strong></td>
-<td><em>string</em></td>
-<td>Hypertext reference to the batch.<br/> <strong>pattern:</strong> <code>/api/v2/user_identities/\d+/programs/\d+/batch_designations/\d+</code></td>
-<td><code>&quot;/api/v2/user_identities/1/programs/42023191739237/batch_designations/74780&quot;</code></td>
-</tr>
-<tr>
 <td><strong>batch:id</strong></td>
 <td><em>integer</em></td>
 <td>Unique identifier of this batch.</td>
 <td><code>74780</code></td>
 </tr>
 <tr>
-<td><strong>batch:result</strong></td>
-<td><em>nullable object</em></td>
-<td>Result of the batch</td>
-<td><code>null</code></td>
-</tr>
-<tr>
-<td><strong>batch:result:designations</strong></td>
+<td><strong>batch:results</strong></td>
 <td><em>nullable array</em></td>
 <td>List of the updated designations</td>
-<td><code>[{&quot;applicant_cas_id&quot;:&quot;123456789&quot;,&quot;decision_id&quot;:99},{&quot;applicant_cas_id&quot;:&quot;987654321&quot;,&quot;decision_id&quot;:123}]</code></td>
+<td><code>[{&quot;decision&quot;:{&quot;id&quot;:4697,&quot;name&quot;:&quot;Matriculated&quot;},&quot;applicant_cas_id&quot;:&quot;1595659994&quot;,&quot;errors&quot;:{&quot;creation_error&quot;:&quot;A newer update (setting decision_id to 4698) is overriding this update&quot;}},{&quot;decision&quot;:{&quot;id&quot;:420,&quot;name&quot;:&quot;Unknown&quot;},&quot;applicant_cas_id&quot;:&quot;1595659995&quot;,&quot;errors&quot;:{&quot;decision&quot;:&quot;No decision found for that decision_id&quot;,&quot;applicant&quot;:&quot;No applicant found for that applicant_cas_id&quot;}},{&quot;decision&quot;:{&quot;id&quot;:4698,&quot;name&quot;:&quot;Redirected&quot;},&quot;applicant_cas_id&quot;:&quot;1595659994&quot;,&quot;errors&quot;:&quot;null&quot;}]</code></td>
 </tr>
 <tr>
-<td><strong>batch:result:designations/applicant_cas_id</strong></td>
+<td><strong>batch:results/applicant_cas_id</strong></td>
 <td><em>string</em></td>
 <td>The CAS unique identifier of the applicant.</td>
 <td><code>&quot;123456789&quot;</code></td>
 </tr>
 <tr>
-<td><strong>batch:result:designations/decision_id</strong></td>
+<td><strong>batch:results/decision:id</strong></td>
 <td><em>integer</em></td>
 <td>The unique identifier for the decision to set. If the designation is in received status and the preliminary_data_handling feature is on, the code will prevent changes to the decision code.</td>
 <td><code>99</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/decision:name</strong></td>
+<td><em>string</em></td>
+<td>Human-readable name for this decision.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors</strong></td>
+<td><em>nullable object</em></td>
+<td></td>
+<td><code>null</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:applicant</strong></td>
+<td><em>string</em></td>
+<td>An error message indicating that the applicant_cas_id provided was invalid.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:creation_error</strong></td>
+<td><em>string</em></td>
+<td>A message explaining why a change could not be completed.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:decision</strong></td>
+<td><em>string</em></td>
+<td>An error message indicating that the decision_id provided was invalid.</td>
+<td><code>&quot;example&quot;</code></td>
 </tr>
 <tr>
 <td><strong>batch:status</strong></td>
 <td><em>string</em></td>
 <td>Current status of this batch.<br/> <strong>one of:</strong><code>&quot;Queued&quot;</code> or <code>&quot;In Progress&quot;</code> or <code>&quot;Available&quot;</code> or <code>&quot;Success With Errors&quot;</code> or <code>&quot;Failed&quot;</code></td>
 <td><code>&quot;Available&quot;</code></td>
+</tr>
+<tr>
+<td><strong>href</strong></td>
+<td><em>string</em></td>
+<td>Hypertext reference to the batch.<br/> <strong>pattern:</strong> <code>/api/v2/user_identities/\d+/programs/\d+/batch_designations/\d+</code></td>
+<td><code>&quot;/api/v2/user_identities/1/programs/42023191739237/batch_designations/74780&quot;</code></td>
 </tr>
 </tbody></table>
 
@@ -113,22 +137,41 @@ batch object in the response.</p>
 </code></pre>
 
 <pre lang="json"><code>{
+  &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_designations/74780&quot;,
   &quot;batch&quot;: {
     &quot;id&quot;: 74780,
-    &quot;href&quot;: &quot;/api/v2/user_identities/1/programs/42023191739237/batch_designations/74780&quot;,
     &quot;status&quot;: &quot;Available&quot;,
-    &quot;result&quot;: {
-      &quot;designations&quot;: [
-        {
-          &quot;applicant_cas_id&quot;: &quot;123456789&quot;,
-          &quot;decision_id&quot;: 99
+    &quot;results&quot;: [
+      {
+        &quot;decision&quot;: {
+          &quot;id&quot;: 4697,
+          &quot;name&quot;: &quot;Matriculated&quot;
         },
-        {
-          &quot;applicant_cas_id&quot;: &quot;987654321&quot;,
-          &quot;decision_id&quot;: 123
+        &quot;applicant_cas_id&quot;: &quot;1595659994&quot;,
+        &quot;errors&quot;: {
+          &quot;creation_error&quot;: &quot;A newer update (setting decision_id to 4698) is overriding this update&quot;
         }
-      ]
-    }
+      },
+      {
+        &quot;decision&quot;: {
+          &quot;id&quot;: 420,
+          &quot;name&quot;: &quot;Unknown&quot;
+        },
+        &quot;applicant_cas_id&quot;: &quot;1595659995&quot;,
+        &quot;errors&quot;: {
+          &quot;decision&quot;: &quot;No decision found for that decision_id&quot;,
+          &quot;applicant&quot;: &quot;No applicant found for that applicant_cas_id&quot;
+        }
+      },
+      {
+        &quot;decision&quot;: {
+          &quot;id&quot;: 4698,
+          &quot;name&quot;: &quot;Redirected&quot;
+        },
+        &quot;applicant_cas_id&quot;: &quot;1595659994&quot;,
+        &quot;errors&quot;: &quot;null&quot;
+      }
+    ]
   }
 }
 </code></pre>

--- a/batch_designations.md
+++ b/batch_designations.md
@@ -34,12 +34,6 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 <td><code>74780</code></td>
 </tr>
 <tr>
-<td><strong>batch:results</strong></td>
-<td><em>nullable array</em></td>
-<td>List of the updated designations</td>
-<td><code>[{&quot;decision&quot;:{&quot;id&quot;:4697,&quot;name&quot;:&quot;Matriculated&quot;},&quot;applicant_cas_id&quot;:&quot;1595659994&quot;,&quot;errors&quot;:{&quot;creation_error&quot;:&quot;A newer update (setting decision_id to 4698) is overriding this update&quot;}},{&quot;decision&quot;:{&quot;id&quot;:420,&quot;name&quot;:&quot;Unknown&quot;},&quot;applicant_cas_id&quot;:&quot;1595659995&quot;,&quot;errors&quot;:{&quot;decision&quot;:&quot;No decision found for that decision_id&quot;,&quot;applicant&quot;:&quot;No applicant found for that applicant_cas_id&quot;}},{&quot;decision&quot;:{&quot;id&quot;:4698,&quot;name&quot;:&quot;Redirected&quot;},&quot;applicant_cas_id&quot;:&quot;1595659994&quot;,&quot;errors&quot;:&quot;null&quot;}]</code></td>
-</tr>
-<tr>
 <td><strong>batch:results/applicant_cas_id</strong></td>
 <td><em>string</em></td>
 <td>The CAS unique identifier of the applicant.</td>
@@ -79,6 +73,18 @@ previous <strong>POST</strong>. Once the batch has finished, the result will be 
 <td><strong>batch:results/errors:decision</strong></td>
 <td><em>string</em></td>
 <td>An error message indicating that the decision_id provided was invalid.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:designation</strong></td>
+<td><em>string</em></td>
+<td>An error message indicating that no designation was found for the given applicant and program.</td>
+<td><code>&quot;example&quot;</code></td>
+</tr>
+<tr>
+<td><strong>batch:results/errors:update_error</strong></td>
+<td><em>string</em></td>
+<td>An error message explaining why the update could not be applied.</td>
 <td><code>&quot;example&quot;</code></td>
 </tr>
 <tr>
@@ -169,7 +175,7 @@ batch object in the response.</p>
           &quot;name&quot;: &quot;Redirected&quot;
         },
         &quot;applicant_cas_id&quot;: &quot;1595659994&quot;,
-        &quot;errors&quot;: &quot;null&quot;
+        &quot;errors&quot;: null
       }
     ]
   }

--- a/schemata/batch_custom_field_answers.json
+++ b/schemata/batch_custom_field_answers.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "http://json-schema.org/draft-04/hyper-schema",
+  "id": "/schemata/batch_custom_field_answers",
+  "title": "Batch Custom Field Answers",
+  "description": "Update custom field answers for a set of applicants in a single API request using a batch action.\nA batch action is an asynchronous operation that can be created using a first endpoint and then have its result checked\nusing another endpoint.\nFirst the batch action is created using the __POST__ (create) endpoint by sending in the request body, the JSON describing all the\nchanges to apply. The creation endpoint validates the changes and then schedules the batch to be executed returning a batch\n**id** to check the result later on.\nThen the __GET__ (show) endpoint can be used to check the completion of the scheduled batch, using the **id** returned by the\nprevious __POST__. Once the batch has finished, the result will be included in the batch object.",
+  "links": [
+    {
+      "description": "Retrieve the status of a running/done batch action initiated with a previous POST. The **id** parameter is required. It is the id of the batch\nthat you wish to check the status of. You may continue to issue this call over a reasonable polling interval (10s) until the batch has finished.\nOnce the status of the batch becomes \"Available\", the detailed information of the modification applied will be in the \"result\" property of the\nbatch object in the response.",
+      "href": "/api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers/:id",
+      "method": "GET",
+      "rel": "self",
+      "title": "Show",
+      "http_header": {
+        "x-api-key": "0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "/schemata/batch_custom_field_answers/definitions/id"
+          }
+        }
+      }
+    },
+    {
+      "description": "Schedule the update of multiple custom field answers with the given applicant CAS IDs and program ID, by creating a batch.",
+      "href": "/api/v2/user_identities/:user_identity_id/programs/:program_id/batch_custom_field_answers",
+      "method": "POST",
+      "rel": "create",
+      "title": "Create",
+      "http_header": {
+        "x-api-key": "0123456789abcdef0123456789abcdef"
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "custom_field_answers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "applicant_cas_id",
+                "custom_field_id",
+                "field_type",
+                "value"
+              ],
+              "properties": {
+                "applicant_cas_id": {
+                  "type": "string",
+                  "description": "The CAS unique identifier of the applicant.",
+                  "example": "123456789"
+                },
+                "custom_field_id": {
+                  "type": "integer",
+                  "description": "Unique identifier of the **custom field** that this answers.",
+                  "example": 4
+                },
+                "field_type": {
+                  "type": "string",
+                  "description": "Type of data that the **custom field** stores.",
+                  "enum": ["boolean", "number", "date", "string", "select"],
+                  "example": "boolean"
+                },
+                "value": {
+                  "type": ["null", "[boolean, string, number, date, select]"],
+                  "description": "The value to be stored as an answer to the **custom field**.",
+
+                  "example": false
+                }
+              }
+            }
+          }
+        }
+      },
+      "targetSchema": {
+        "type": "object",
+        "properties": {
+          "batch": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "$ref": "/schemata/batch_custom_field_answers/definitions/id"
+              },
+              "href": {
+                "$ref": "/schemata/batch_custom_field_answers/definitions/href"
+              },
+              "status": {
+                "$ref": "/schemata/batch_custom_field_answers/definitions/status",
+                "example": "Queued"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "id": {
+      "type": "integer",
+      "example": 74780,
+      "description": "Unique identifier of this batch."
+    },
+    "href": {
+      "type": "string",
+      "description": "Hypertext reference to the batch.",
+      "pattern": "/api/v2/user_identities/\\d+/programs/\\d+/batch_custom_field_answers/\\d+",
+      "example": "/api/v2/user_identities/1/programs/42023191739237/batch_custom_field_answers/74780"
+    },
+    "status": {
+      "type": "string",
+      "description": "Current status of this batch.",
+      "enum": [
+        "Queued",
+        "In Progress",
+        "Available",
+        "Success With Errors",
+        "Failed"
+      ],
+      "example": "Available"
+    }
+  },
+  "properties": {
+    "batch": {
+      "type": "object",
+      "required": [
+        "id",
+        "href",
+        "status"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "/schemata/batch_custom_field_answers/definitions/id"
+        },
+        "href": {
+          "$ref": "/schemata/batch_custom_field_answers/definitions/href"
+        },
+        "status": {
+          "$ref": "/schemata/batch_custom_field_answers/definitions/status"
+        },
+        "result": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "description": "Result of the batch",
+          "properties": {
+            "custom_field_answers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "description": "List of the updated custom field answers",
+              "example": [
+                {
+                  "applicant_cas_id": "123456789",
+                  "custom_field_id": 99,
+                  "field_type": "boolean",
+                  "value": false
+                },
+                {
+                  "applicant_cas_id": "987654321",
+                  "custom_field_id": 123,
+                  "field_type": "string",
+                  "value": "banana"
+                }
+              ],
+              "items": {
+                "type": "object",
+                "required": [
+                  "applicant_cas_id",
+                  "custom_field_id",
+                  "field_type",
+                  "value"
+                ],
+                "properties": {
+                  "applicant_cas_id": {
+                    "type": "string",
+                    "description": "The CAS unique identifier of the applicant.",
+                    "example": "123456789"
+                  },
+                  "custom_field_id": {
+                    "type": "integer",
+                    "description": "Unique identifier of the **custom field** that this answers.",
+                    "example": 99
+                  },
+                  "field_type": {
+                    "type": "string",
+                    "description": "Type of data that the **custom field** stores.",
+                    "example": "boolean"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "The value to be stored as an answer to the **custom field**.",
+                    "example": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemata/batch_custom_field_answers.json
+++ b/schemata/batch_custom_field_answers.json
@@ -140,51 +140,54 @@
         "status": {
           "$ref": "/schemata/batch_custom_field_answers/definitions/status"
         },
-        "result": {
+        "results": {
           "type": [
-            "object",
+            "array",
             "null"
           ],
-          "description": "Result of the batch",
-          "properties": {
-            "custom_field_answers": {
-              "type": [
-                "array",
-                "null"
-              ],
-              "description": "List of the updated custom field answers",
-              "example": [
-                {
-                  "applicant_cas_id": "123456789",
-                  "custom_field_id": 99,
-                  "field_type": "boolean",
-                  "value": false
-                },
-                {
-                  "applicant_cas_id": "987654321",
-                  "custom_field_id": 123,
-                  "field_type": "string",
-                  "value": "banana"
-                }
-              ],
-              "items": {
-                "type": "object",
-                "required": [
-                  "applicant_cas_id",
-                  "custom_field_id",
-                  "field_type",
-                  "value"
+          "description": "List of the updated custom field answers",
+          "example": [
+            {
+              "custom_field_answer": {
+                "custom_field_id": 99,
+                "label": "Are you a citizen?",
+                "field_type": "boolean",
+                "value": false
+              },
+              "applicant_cas_id": "123456789"
+            },
+            {
+              "custom_field_answer": {
+                "custom_field_id": 123,
+                "label": "What is your favorite fruit?",
+                "field_type": "string",
+                "value": "banana"
+              },
+              "applicant_cas_id": "987654321"
+            }
+          ],
+          "items": {
+            "type": "object",
+            "required": [
+              "custom_field_answer"
+            ],
+            "properties": {
+              "custom_field_answer": {
+                "type": [
+                  "object",
+                  "null"
                 ],
+                "description": "Result of the batch",
                 "properties": {
-                  "applicant_cas_id": {
-                    "type": "string",
-                    "description": "The CAS unique identifier of the applicant.",
-                    "example": "123456789"
-                  },
                   "custom_field_id": {
                     "type": "integer",
                     "description": "Unique identifier of the **custom field** that this answers.",
                     "example": 99
+                  },
+                  "label": {
+                    "type": "string",
+                    "description": "Human-readable label for the custom field..",
+                    "example": "What is your favorite color?"
                   },
                   "field_type": {
                     "type": "string",
@@ -197,6 +200,11 @@
                     "example": false
                   }
                 }
+              },
+              "applicant_cas_id": {
+                "type": "string",
+                "description": "The CAS unique identifier of the applicant.",
+                "example": "123456789"
               }
             }
           }

--- a/schemata/batch_custom_field_answers.json
+++ b/schemata/batch_custom_field_answers.json
@@ -169,13 +169,18 @@
           "items": {
             "type": "object",
             "required": [
-              "custom_field_answer"
+              "custom_field_answer",
+              "applicant_cas_id",
+              "errors"
             ],
             "properties": {
               "custom_field_answer": {
-                "type": [
-                  "object",
-                  "null"
+                "type": "object",
+                "required": [
+                  "custom_field_id",
+                  "label",
+                  "field_type",
+                  "value"
                 ],
                 "description": "Result of the batch",
                 "properties": {
@@ -205,6 +210,30 @@
                 "type": "string",
                 "description": "The CAS unique identifier of the applicant.",
                 "example": "123456789"
+              },
+              "errors": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "creation_error": {
+                    "type": "string",
+                    "description": "A message explaining why a change could not be completed."
+                  },
+                  "update_error": {
+                    "type": "string",
+                    "description": "An error message explaining why the update could not be applied."
+                  },
+                  "applicant": {
+                    "type": "string",
+                    "description": "An error message indicating that the applicant_cas_id provided was invalid."
+                  },
+                  "custom_field": {
+                    "type": "string",
+                    "description": "An error message indicating that the custom_field_id provided was invalid."
+                  }
+                }
               }
             }
           }

--- a/schemata/batch_custom_field_answers.json
+++ b/schemata/batch_custom_field_answers.json
@@ -78,14 +78,14 @@
       "targetSchema": {
         "type": "object",
         "properties": {
+          "href": {
+            "$ref": "/schemata/batch_custom_field_answers/definitions/href"
+          },
           "batch": {
             "type": "object",
             "properties": {
               "id": {
                 "$ref": "/schemata/batch_custom_field_answers/definitions/id"
-              },
-              "href": {
-                "$ref": "/schemata/batch_custom_field_answers/definitions/href"
               },
               "status": {
                 "$ref": "/schemata/batch_custom_field_answers/definitions/status",
@@ -123,19 +123,18 @@
     }
   },
   "properties": {
+    "href": {
+      "$ref": "/schemata/batch_custom_field_answers/definitions/href"
+    },
     "batch": {
       "type": "object",
       "required": [
         "id",
-        "href",
         "status"
       ],
       "properties": {
         "id": {
           "$ref": "/schemata/batch_custom_field_answers/definitions/id"
-        },
-        "href": {
-          "$ref": "/schemata/batch_custom_field_answers/definitions/href"
         },
         "status": {
           "$ref": "/schemata/batch_custom_field_answers/definitions/status"
@@ -154,7 +153,8 @@
                 "field_type": "boolean",
                 "value": false
               },
-              "applicant_cas_id": "123456789"
+              "applicant_cas_id": "123456789",
+              "errors": null
             },
             {
               "custom_field_answer": {
@@ -163,7 +163,10 @@
                 "field_type": "string",
                 "value": "banana"
               },
-              "applicant_cas_id": "987654321"
+              "applicant_cas_id": "987654321",
+              "errors": {
+                "applicant": "No applicant found for that applicant_cas_id"
+              }
             }
           ],
           "items": {

--- a/schemata/batch_designations.json
+++ b/schemata/batch_designations.json
@@ -119,6 +119,9 @@
     }
   },
   "properties": {
+    "href": {
+      "$ref": "/schemata/batch_designations/definitions/href"
+    },
     "batch": {
       "type": "object",
       "required": [
@@ -130,47 +133,89 @@
         "id": {
           "$ref": "/schemata/batch_designations/definitions/id"
         },
-        "href": {
-          "$ref": "/schemata/batch_designations/definitions/href"
-        },
         "status": {
           "$ref": "/schemata/batch_designations/definitions/status"
         },
-        "result": {
+        "results": {
           "type": [
-            "object",
+            "array",
             "null"
           ],
-          "description": "Result of the batch",
-          "properties": {
-            "designations": {
-              "type": [
-                "array",
-                "null"
-              ],
-              "description": "List of the updated designations",
-              "example": [
-                {
-                  "applicant_cas_id": "123456789",
-                  "decision_id": 99
-                },
-                {
-                  "applicant_cas_id": "987654321",
-                  "decision_id": 123
-                }
-              ],
-              "items": {
+          "description": "List of the updated designations",
+          "example": [
+            {
+              "decision": {
+                "id": 4697,
+                "name": "Matriculated"
+              },
+              "applicant_cas_id": "1595659994",
+              "errors": {
+                "creation_error": "A newer update (setting decision_id to 4698) is overriding this update"
+              }
+            },
+            {
+              "decision": {
+                "id": 420,
+                "name": "Unknown"
+              },
+              "applicant_cas_id": "1595659995",
+              "errors": {
+                "decision": "No decision found for that decision_id",
+                "applicant": "No applicant found for that applicant_cas_id"
+              }
+            },
+            {
+              "decision": {
+                "id": 4698,
+                "name": "Redirected"
+              },
+              "applicant_cas_id": "1595659994",
+              "errors": "null"
+            }
+          ],
+          "items": {
+            "type": "object",
+            "required": [
+              "decision",
+              "applicant_cas_id"
+            ],
+            "properties": {
+              "decision": {
                 "type": "object",
                 "required": [
-                  "applicant_cas_id",
-                  "decision_id"
+                  "id",
+                  "name"
                 ],
                 "properties": {
-                  "applicant_cas_id": {
-                    "$ref": "/schemata/batch_designations/definitions/applicant_cas_id"
+                  "name": {
+                    "type": "string",
+                    "description": "Human-readable name for this decision."
                   },
-                  "decision_id": {
+                  "id": {
                     "$ref": "/schemata/batch_designations/definitions/decision_id"
+                  }
+                }
+              },
+              "applicant_cas_id": {
+                "$ref": "/schemata/batch_designations/definitions/applicant_cas_id"
+              },
+              "errors": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "properties": {
+                  "creation_error": {
+                    "type": "string",
+                    "description": "A message explaining why a change could not be completed."
+                  },
+                  "decision": {
+                    "type": "string",
+                    "description": "An error message indicating that the decision_id provided was invalid."
+                  },
+                  "applicant": {
+                    "type": "string",
+                    "description": "An error message indicating that the applicant_cas_id provided was invalid."
                   }
                 }
               }

--- a/schemata/batch_designations.json
+++ b/schemata/batch_designations.json
@@ -137,10 +137,7 @@
           "$ref": "/schemata/batch_designations/definitions/status"
         },
         "results": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "description": "List of the updated designations",
           "example": [
             {
@@ -170,14 +167,15 @@
                 "name": "Redirected"
               },
               "applicant_cas_id": "1595659994",
-              "errors": "null"
+              "errors": null
             }
           ],
           "items": {
             "type": "object",
             "required": [
               "decision",
-              "applicant_cas_id"
+              "applicant_cas_id",
+              "errors"
             ],
             "properties": {
               "decision": {
@@ -216,6 +214,14 @@
                   "applicant": {
                     "type": "string",
                     "description": "An error message indicating that the applicant_cas_id provided was invalid."
+                  },
+                  "designation": {
+                    "type": "string",
+                    "description": "An error message indicating that no designation was found for the given applicant and program."
+                  },
+                  "update_error": {
+                    "type": "string",
+                    "description": "An error message explaining why the update could not be applied."
                   }
                 }
               }

--- a/schemata/batch_designations.json
+++ b/schemata/batch_designations.json
@@ -64,14 +64,14 @@
       "targetSchema": {
         "type": "object",
         "properties": {
+          "href": {
+            "$ref": "/schemata/batch_designations/definitions/href"
+          },
           "batch": {
             "type": "object",
             "properties": {
               "id": {
                 "$ref": "/schemata/batch_designations/definitions/id"
-              },
-              "href": {
-                "$ref": "/schemata/batch_designations/definitions/href"
               },
               "status": {
                 "$ref": "/schemata/batch_designations/definitions/status",

--- a/script/generate-docs
+++ b/script/generate-docs
@@ -107,3 +107,4 @@ generate_markdown_from_json_schema 'Export/Report Files check status' 'export_fi
 generate_markdown_from_json_schema 'Export/Report Files initiate a run' 'export_files.json' '' '' 'not_found.md' > 'export_files.md'
 generate_markdown_from_json_schema 'Applicant Details' 'applicant_details.json' '' 'prototype.md' 'not_found.md' > 'applicant_details.md'
 generate_markdown_from_json_schema 'Batch Designations' 'batch_designations.json' '' 'prototype.md' 'batch_designations_errors.md batch_not_found_errors.md' > 'batch_designations.md'
+generate_markdown_from_json_schema 'Batch Custom Field Answers' 'batch_custom_field_answers.json' '' 'prototype.md' 'batch_custom_field_answers_errors.md batch_not_found_errors.md' > 'batch_custom_field_answers.md'


### PR DESCRIPTION
This adds the documentation to for batch custom field answers as well as
updates it to use custom error documentation. This follows the pattern
set in the batch designations documentation.

This also updates the documentation response object for both of the batch API show actions.

Batch designations:
<img width="1156" alt="Screen Shot 2019-12-17 at 2 12 03 PM" src="https://user-images.githubusercontent.com/1719129/71031058-4ae88a80-20d8-11ea-9791-f3d62543aaaf.png">
<img width="1145" alt="Screen Shot 2019-12-17 at 2 12 10 PM" src="https://user-images.githubusercontent.com/1719129/71031059-4ae88a80-20d8-11ea-9758-516432015dee.png">
<img width="933" alt="Screen Shot 2019-12-17 at 2 12 21 PM" src="https://user-images.githubusercontent.com/1719129/71031061-4ae88a80-20d8-11ea-8d18-3a7852d37d72.png">
<img width="931" alt="Screen Shot 2019-12-17 at 2 12 28 PM" src="https://user-images.githubusercontent.com/1719129/71031063-4ae88a80-20d8-11ea-9bc3-77a81a0f58ab.png">
<img width="935" alt="Screen Shot 2019-12-17 at 2 12 38 PM" src="https://user-images.githubusercontent.com/1719129/71031064-4b812100-20d8-11ea-92da-8a5cd10f3cea.png">
<img width="941" alt="Screen Shot 2019-12-17 at 2 12 45 PM" src="https://user-images.githubusercontent.com/1719129/71031065-4b812100-20d8-11ea-8a6d-dbd5068b986f.png">
<img width="943" alt="Screen Shot 2019-12-17 at 2 12 55 PM" src="https://user-images.githubusercontent.com/1719129/71031068-4b812100-20d8-11ea-95b5-a01999150d43.png">

Batch Custom Field Answers
<img width="1319" alt="Screen Shot 2019-12-17 at 2 16 04 PM" src="https://user-images.githubusercontent.com/1719129/71031097-59cf3d00-20d8-11ea-9421-ad44f6725040.png">
<img width="1325" alt="Screen Shot 2019-12-17 at 2 16 13 PM" src="https://user-images.githubusercontent.com/1719129/71031099-59cf3d00-20d8-11ea-8119-357af602e031.png">
<img width="931" alt="Screen Shot 2019-12-17 at 2 16 22 PM" src="https://user-images.githubusercontent.com/1719129/71031100-59cf3d00-20d8-11ea-8f40-b9deaac0ad25.png">
<img width="935" alt="Screen Shot 2019-12-17 at 2 16 31 PM" src="https://user-images.githubusercontent.com/1719129/71031101-5a67d380-20d8-11ea-8cd1-ef0d357a540d.png">
<img width="927" alt="Screen Shot 2019-12-17 at 2 16 41 PM" src="https://user-images.githubusercontent.com/1719129/71031102-5a67d380-20d8-11ea-9b93-3b9fddebcd4e.png">
<img width="928" alt="Screen Shot 2019-12-17 at 2 16 49 PM" src="https://user-images.githubusercontent.com/1719129/71031103-5a67d380-20d8-11ea-9072-5a3cc0bb7dd1.png">
<img width="937" alt="Screen Shot 2019-12-17 at 2 16 56 PM" src="https://user-images.githubusercontent.com/1719129/71031105-5a67d380-20d8-11ea-9555-385e7cfb563b.png">
